### PR TITLE
Set implicit timeouts on test runs

### DIFF
--- a/test/apply/specs/index.js
+++ b/test/apply/specs/index.js
@@ -86,6 +86,7 @@ const addProtocol = browser => {
 describe('PPL Application', () => {
 
   it('can apply for a PPL', () => {
+    browser.timeouts('implicit', 2000);
     browser.withUser('basic');
 
     browser.url('/');

--- a/test/endorse/specs/index.js
+++ b/test/endorse/specs/index.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 describe('PPL endorsement', () => {
 
   it('can be endorsed by an admin user', () => {
+    browser.timeouts('implicit', 2000);
     browser.withUser('holc');
     browser.url('/');
 

--- a/test/grant/specs/index.js
+++ b/test/grant/specs/index.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 describe('PPL Grant', () => {
 
   it('can grant a PPL', () => {
+    browser.timeouts('implicit', 2000);
     browser.withUser('licensing');
 
     browser.click('a=In progress');

--- a/test/recommend/specs/index.js
+++ b/test/recommend/specs/index.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 describe('PPL Recommendation', () => {
 
   it('can recommend a PPL', () => {
+    browser.timeouts('implicit', 2000);
     browser.withUser('inspector');
 
     browser.click('a=In progress');


### PR DESCRIPTION
By default this is zero, which can cause occasional race conditions to fail tests. Setting to 2000 doesn't seem to impact performance, but tests run more reliably.