### PR TITLE
Prevent infinite loop when no successor words

### DIFF
--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -12,7 +12,9 @@ const randomWord = predecessor => {
     const successors = corpus
       .map((word, i) => word.toLowerCase() === predecessor.toLowerCase() ? corpus[i + 1] : null)
       .filter(Boolean);
-    return successors[between(0, successors.length)];
+    if (successors.length) {
+      return successors[between(0, successors.length)];
+    }
   }
   return corpus[between(0, corpus.length)];
 };


### PR DESCRIPTION
There's the potential for the text generator to end up in an infinite loop if it if picks the last word of the corpus. Fall back to picking one at random if there are no successors.