### PR TITLE
Remove second sort on task list

### DIFF
--- a/test/utils/goto-tasks.js
+++ b/test/utils/goto-tasks.js
@@ -12,8 +12,8 @@ module.exports = (type = 'Outstanding') => function () {
   });
   this.$(`a=${type}`).click();
   this.$('table:not(.loading) th a:not(.disabled)').waitForExist();
-  this.$('th').$(`a=${latestLabel}`).click();
-  this.$('table:not(.loading) th a:not(.disabled)').waitForExist();
-  this.$('th').$(`a=${latestLabel}`).click();
-  this.$('table:not(.loading)').waitForExist();
+  if (this.$(`th=${latestLabel}`).getAttribute('aria-sort') === 'ascending') {
+    this.$('th').$(`a=${latestLabel}`).click();
+    this.$('table:not(.loading)').waitForExist();
+  }
 };


### PR DESCRIPTION
Sorting now works correctly so it's not necessary to sort the table twice to get the latest tasks to the top.