### PR TITLE
Use id properties to select site and area

### DIFF
--- a/test/place/create/specs/index.js
+++ b/test/place/create/specs/index.js
@@ -6,8 +6,8 @@ describe('Create place', () => {
     browser.gotoPlaces();
 
     browser.$('a*=Create').click();
-    browser.$('input[name=site]').setValue('Autoproject site');
-    browser.$('input[name=area]').setValue('Autoproject area');
+    browser.$('input#site').setValue('Autoproject site');
+    browser.$('input#area').setValue('Autoproject area');
     browser.$('input[name=name]').setValue(process.env.PLACE_NAME);
     browser
       .$('#suitability')


### PR DESCRIPTION
These are now autocompletes and so the name refers to the associated hidden field.